### PR TITLE
Add awslambda.update_environment_variables

### DIFF
--- a/boto3_helpers/awslambda.py
+++ b/boto3_helpers/awslambda.py
@@ -1,0 +1,47 @@
+from boto3 import client as boto3_client
+
+
+def update_environment_variables(function_name, new_env, *, lambda_client=None):
+    """Do a partial update of a Lambda function's environment variables. Return the
+    resulting environment.
+
+    * *function_name* is the Lambda function name.
+    * *new_env* is a mapping with the new environment variables
+    * *lambda_client* is a ``boto3.client('lambda')`` instance. If not given, one will
+      be created with ``boto3.client('lambda')``.
+
+    Usage:
+
+    .. code-block:: python
+
+        from boto3_helpers.awslambda import update_environment_variables
+
+        new_env = {'LOG_LEVEL': 'INFO', 'LOG_SERVER': '198.51.100.1'}
+        result_env = update_environment_variables(
+            'ExamplePlaybackConfig',
+            AdDecisionServerUrl='https://198.51.100.1:24601/ads/',
+        )
+        assert result_env['LOG_LEVEL'] == 'INFO'
+        assert result_env['LOG_SERVER'] == '198.51.100.1'
+        assert result_env['LOG_PORT'] == '24601'  # Or whatever it was before
+
+    The function's existing environment variables will be fetched, merged with the
+    *new_env*, and sent to the Lambda API.
+
+    .. note::
+
+        It's possible for another API user to change environment variables
+        in between this function's calls to  ``get_function_configuration`` and
+        ``update_function_configuration``. The Lambda API doesn't allow for atomic
+        updates.
+    """
+    lambda_client = lambda_client or boto3_client('lambda')
+
+    resp = lambda_client.get_function_configuration(FunctionName=function_name)
+    env = resp.get('Environment', {}).get('Variables', {})
+    env.update(new_env)
+
+    lambda_client.update_function_configuration(
+        FunctionName=function_name, Environment={'Variables': env}
+    )
+    return env

--- a/boto3_helpers/awslambda.py
+++ b/boto3_helpers/awslambda.py
@@ -6,7 +6,7 @@ def update_environment_variables(function_name, new_env, *, lambda_client=None):
     resulting environment.
 
     * *function_name* is the Lambda function name.
-    * *new_env* is a mapping with the new environment variables
+    * *new_env* is a mapping with the new environment variables.
     * *lambda_client* is a ``boto3.client('lambda')`` instance. If not given, one will
       be created with ``boto3.client('lambda')``.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,12 @@ DynamoDB Helpers
 .. automodule:: boto3_helpers.dynamodb
     :members:
 
+Lambda Helpers
+-------------------
+
+.. automodule:: boto3_helpers.awslambda
+    :members:
+
 MediaTailor Helpers
 -------------------
 

--- a/tests/test_awslambda.py
+++ b/tests/test_awslambda.py
@@ -1,0 +1,52 @@
+from copy import deepcopy
+from unittest import TestCase
+
+from boto3 import client as boto3_client
+from botocore.stub import Stubber
+
+from boto3_helpers.awslambda import update_environment_variables
+
+
+class AWSLambdaTests(TestCase):
+    def test_update_environment_variables(self):
+        # Set up the stubber
+        lambda_client = boto3_client('lambda', region_name='not-a-region')
+        stubber = Stubber(lambda_client)
+
+        function_name = 'TestFunction'
+        current_env = {'LOG_SERVER': '192.0.2.1', 'LOG_PORT': '24601'}
+        new_env = {'LOG_SERVER': '198.51.100.1', 'LOG_LEVEL': 'INFO'}
+        combined_env = {
+            'LOG_SERVER': '198.51.100.1',
+            'LOG_PORT': '24601',
+            'LOG_LEVEL': 'INFO',
+        }
+
+        # First is the get command
+        get_params = {'FunctionName': function_name}
+        get_resp = {
+            'FunctionName': function_name,
+            'Environment': {'Variables': current_env},
+        }
+        stubber.add_response('get_function_configuration', get_resp, get_params)
+
+        # Next is the put command - everything should be the same as above,
+        # but the target valus should be updated and the read-only values not present.
+        update_params = {
+            'FunctionName': function_name,
+            'Environment': {'Variables': combined_env},
+        }
+        update_resp = deepcopy(update_params)
+        stubber.add_response(
+            'update_function_configuration', update_resp, update_params
+        )
+
+        # Do the deed - we expect to get the put response back
+        with stubber:
+            actual = update_environment_variables(
+                function_name,
+                new_env,
+                lambda_client=lambda_client,
+            )
+
+        self.assertEqual(actual, combined_env)


### PR DESCRIPTION
This PR adds `boto3_helpers.awslambda.update_environment_variables`, which is used for partial updates of AWS Lambda function environment variables.