### PR TITLE
Kinesis helpers

### DIFF
--- a/boto3_helpers/kinesis.py
+++ b/boto3_helpers/kinesis.py
@@ -73,9 +73,10 @@ def yield_available_shard_records(kinesis_client=None, **kwargs):
     while True:
         resp = kinesis_client.get_records(ShardIterator=shard_iterator)
         yield from resp.get('Records', [])
-        if not resp['MillisBehindLatest']:
+
+        shard_iterator = resp.get('NextShardIterator')
+        if (not resp['MillisBehindLatest']) or (not shard_iterator):
             break
-        shard_iterator = resp['NextShardIterator']
 
 
 def yield_available_stream_records(kinesis_client=None, **kwargs):

--- a/boto3_helpers/kinesis.py
+++ b/boto3_helpers/kinesis.py
@@ -1,15 +1,16 @@
 from boto3 import client as boto3_client
 
+
 def yield_all_shards(kinesis_client=None, **kwargs):
     """Due to a `bug <https://github.com/boto/botocore/issues/2009>`_ in ``botocore``,
     the ``list_shards`` paginator does not work correctly. This function yields
     the information from all shards in a Kinesis stream.
-    
+
     * *kinesis_client* is a ``boto3.client('kinesis_client')`` instance. If not given,
       one will be created with ``boto3.client('kinesis_client')``.
     * *kwargs* are passed directly to the ``list_shards`` method. You probably want to
       supply at least ``StreamName``.
-    
+
     Usage:
 
     .. code-block:: python

--- a/boto3_helpers/kinesis.py
+++ b/boto3_helpers/kinesis.py
@@ -1,3 +1,5 @@
+from itertools import chain, zip_longest
+
 from boto3 import client as boto3_client
 
 
@@ -39,3 +41,94 @@ def yield_all_shards(kinesis_client=None, **kwargs):
         if not next_token:
             break
         kwargs['NextToken'] = next_token
+
+
+def yield_available_shard_records(StreamName, ShardId, kinesis_client=None, **kwargs):
+    """Yield all available records from the given Kinesis stream shard.
+    Records will be pulled from until ``MillisBehindLatest`` is zero.
+
+    * *StreamName* is the name of the stream.
+    * *ShardId* is the ID of the shard.
+    * *kinesis_client* is a ``boto3.client('kinesis_client')`` instance. If not given,
+      one will be created with ``boto3.client('kinesis_client')``.
+    * *kwargs* are passed directly to the ``get_shard_iterator`` method. By default
+      you'll get records from the stream's ``TRIM_HORIZON``.
+
+    Reading from the earliest available record:
+
+    .. code-block:: python
+
+        from datetime import datetime, timedelta, timezone
+        from boto3_helpers.kinesis import yield_available_shard_records
+
+        for record in yield_available_shard_records('example-stream', 'shard-0001'):
+            print(record['SequenceNumber], record['Data], sep='\t')
+
+    """
+    kinesis_client = kinesis_client or boto3_client('kinesis')
+
+    kwargs.setdefault('ShardIteratorType', 'TRIM_HORIZON')
+    shard_iterator = kinesis_client.get_shard_iterator(
+        StreamName=StreamName, ShardId=ShardId, **kwargs
+    )['ShardIterator']
+
+    while True:
+        resp = kinesis_client.get_records(ShardIterator=shard_iterator)
+        yield from resp.get('Records', [])
+        if not resp['MillisBehindLatest']:
+            break
+        shard_iterator = resp['NextShardIterator']
+
+
+def yield_available_stream_records(StreamName, kinesis_client=None, **kwargs):
+    """Yield all available records from the given Kinesis stream.
+    Records will be pulled from each of the stream's shards until ``MillisBehindLatest``
+    is zero. The shards' records will be interleaved together (example: if a stream has
+    three shards, the first record yielded will be from shard A, the second will be from
+    shard B, the third will be from shard, the fourth will be from shard A, etc.).
+
+    * *StreamName* is the name of the stream.
+    * *kinesis_client* is a ``boto3.client('kinesis_client')`` instance. If not given,
+      one will be created with ``boto3.client('kinesis_client')``.
+    * *kwargs* are passed directly to the ``get_shard_iterator`` method. By default
+      you'll get records from the stream's ``TRIM_HORIZON``.
+
+    Reading from the earliest available record:
+
+    .. code-block:: python
+
+        from datetime import datetime, timedelta, timezone
+        from boto3_helpers.kinesis import yield_available_stream_records
+
+        for record in yield_available_stream_records('example-stream'):
+            print(record['SequenceNumber], record['Data], sep='\t')
+
+    Reading from a particular timestamp:
+
+    .. code-block:: python
+
+        from datetime import datetime, timedelta, timezone
+        from boto3_helpers.kinesis import yield_available_stream_records
+
+        for record in yield_available_stream_records(
+            'example-stream',
+            ShardIteratorType='AT_TIMESTAMP',
+            Timestamp=datetime.now(timezone.utc) - timedelta(hours=1),
+        ):
+            print(record['SequenceNumber], record['Data], sep='\t')
+
+    .. note::
+
+        This is a synchronous function, and may not be fast enough for real-time
+        processing of high volume streams.
+    """
+    all_shard_records = []
+    for shard in yield_all_shards(StreamName=StreamName, kinesis_client=kinesis_client):
+        shard_records = yield_available_shard_records(
+            StreamName, shard['ShardId'], kinesis_client=kinesis_client, **kwargs
+        )
+        all_shard_records.append(shard_records)
+
+    for item in chain.from_iterable(zip_longest(*all_shard_records)):
+        if item is not None:
+            yield item

--- a/boto3_helpers/kinesis.py
+++ b/boto3_helpers/kinesis.py
@@ -1,0 +1,40 @@
+from boto3 import client as boto3_client
+
+def yield_all_shards(kinesis_client=None, **kwargs):
+    """Due to a `bug <https://github.com/boto/botocore/issues/2009>`_ in ``botocore``,
+    the ``list_shards`` paginator does not work correctly. This function yields
+    the information from all shards in a Kinesis stream.
+    
+    * *kinesis_client* is a ``boto3.client('kinesis_client')`` instance. If not given,
+      one will be created with ``boto3.client('kinesis_client')``.
+    * *kwargs* are passed directly to the ``list_shards`` method. You probably want to
+      supply at least ``StreamName``.
+    
+    Usage:
+
+    .. code-block:: python
+
+        from boto3_helpers.kinesis import yield_all_shards
+
+        for shard in yield_all_shards(StreamName='example-stream'):
+            print(shard['ShardId'])
+
+    """
+    kinesis_client = kinesis_client or boto3_client('kinesis')
+
+    while True:
+        # The API docs say:
+        # "You cannot specify this parameter if you specify the NextToken parameter"
+        # for the three parameters below. This is why the standard paging tool fails.
+        if 'NextToken' in kwargs:
+            kwargs.pop('StreamName', None)
+            kwargs.pop('ExclusiveStartShardId', None)
+            kwargs.pop('StreamCreationTimestamp', None)
+
+        resp = kinesis_client.list_shards(**kwargs)
+        yield from resp.get('Shards', [])
+
+        next_token = resp.get('NextToken')
+        if not next_token:
+            break
+        kwargs['NextToken'] = next_token

--- a/boto3_helpers/kinesis.py
+++ b/boto3_helpers/kinesis.py
@@ -10,8 +10,8 @@ def yield_all_shards(kinesis_client=None, **kwargs):
 
     * *kinesis_client* is a ``boto3.client('kinesis_client')`` instance. If not given,
       one will be created with ``boto3.client('kinesis_client')``.
-    * *kwargs* are passed directly to the ``list_shards`` method. You probably want to
-      supply at least ``StreamName``.
+    * *kwargs* are passed directly to the ``list_shards`` method.
+      You'll need to supply at least *StreamARN* or *StreamName*.
 
     Usage:
 
@@ -43,16 +43,16 @@ def yield_all_shards(kinesis_client=None, **kwargs):
         kwargs['NextToken'] = next_token
 
 
-def yield_available_shard_records(StreamName, ShardId, kinesis_client=None, **kwargs):
+def yield_available_shard_records(kinesis_client=None, **kwargs):
     """Yield all available records from the given Kinesis stream shard.
     Records will be pulled from until ``MillisBehindLatest`` is zero.
 
-    * *StreamName* is the name of the stream.
     * *ShardId* is the ID of the shard.
     * *kinesis_client* is a ``boto3.client('kinesis_client')`` instance. If not given,
       one will be created with ``boto3.client('kinesis_client')``.
-    * *kwargs* are passed directly to the ``get_shard_iterator`` method. By default
-      you'll get records from the stream's ``TRIM_HORIZON``.
+    * *kwargs* are passed directly to the ``get_shard_iterator`` method.
+      You'll need to supply at least *StreamARN* (or *StreamName*) and *ShardId*.
+      By default you'll get records from the stream's ``TRIM_HORIZON``.
 
     Reading from the earliest available record:
 
@@ -68,9 +68,7 @@ def yield_available_shard_records(StreamName, ShardId, kinesis_client=None, **kw
     kinesis_client = kinesis_client or boto3_client('kinesis')
 
     kwargs.setdefault('ShardIteratorType', 'TRIM_HORIZON')
-    shard_iterator = kinesis_client.get_shard_iterator(
-        StreamName=StreamName, ShardId=ShardId, **kwargs
-    )['ShardIterator']
+    shard_iterator = kinesis_client.get_shard_iterator(**kwargs)['ShardIterator']
 
     while True:
         resp = kinesis_client.get_records(ShardIterator=shard_iterator)
@@ -80,18 +78,18 @@ def yield_available_shard_records(StreamName, ShardId, kinesis_client=None, **kw
         shard_iterator = resp['NextShardIterator']
 
 
-def yield_available_stream_records(StreamName, kinesis_client=None, **kwargs):
+def yield_available_stream_records(kinesis_client=None, **kwargs):
     """Yield all available records from the given Kinesis stream.
     Records will be pulled from each of the stream's shards until ``MillisBehindLatest``
     is zero. The shards' records will be interleaved together (example: if a stream has
     three shards, the first record yielded will be from shard A, the second will be from
     shard B, the third will be from shard, the fourth will be from shard A, etc.).
 
-    * *StreamName* is the name of the stream.
     * *kinesis_client* is a ``boto3.client('kinesis_client')`` instance. If not given,
       one will be created with ``boto3.client('kinesis_client')``.
-    * *kwargs* are passed directly to the ``get_shard_iterator`` method. By default
-      you'll get records from the stream's ``TRIM_HORIZON``.
+    * *kwargs* are passed directly to the ``get_shard_iterator`` method.
+      You'll need to supply at least *StreamARN* or *StreamName*.
+      By default you'll get records from the stream's ``TRIM_HORIZON``.
 
     Reading from the earliest available record:
 
@@ -100,7 +98,7 @@ def yield_available_stream_records(StreamName, kinesis_client=None, **kwargs):
         from datetime import datetime, timedelta, timezone
         from boto3_helpers.kinesis import yield_available_stream_records
 
-        for record in yield_available_stream_records('example-stream'):
+        for record in yield_available_stream_records(StreamName='example-stream'):
             print(record['SequenceNumber], record['Data], sep='\t')
 
     Reading from a particular timestamp:
@@ -122,10 +120,15 @@ def yield_available_stream_records(StreamName, kinesis_client=None, **kwargs):
         This is a synchronous function, and may not be fast enough for real-time
         processing of high volume streams.
     """
+    list_shards_kwargs = {}
+    for key in ('StreamName', 'StreamARN'):
+        if key in kwargs:
+            list_shards_kwargs[key] = kwargs[key]
+
     all_shard_records = []
-    for shard in yield_all_shards(StreamName=StreamName, kinesis_client=kinesis_client):
+    for shard in yield_all_shards(kinesis_client=kinesis_client, **list_shards_kwargs):
         shard_records = yield_available_shard_records(
-            StreamName, shard['ShardId'], kinesis_client=kinesis_client, **kwargs
+            ShardId=shard['ShardId'], kinesis_client=kinesis_client, **kwargs
         )
         all_shard_records.append(shard_records)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,12 @@ DynamoDB Helpers
 .. automodule:: boto3_helpers.dynamodb
     :members:
 
+Kinesis Helpers
+----------------
+
+.. automodule:: boto3_helpers.kinesis
+    :members:
+
 MediaTailor Helpers
 -------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,7 +38,6 @@ Kinesis Helpers
 .. automodule:: boto3_helpers.kinesis
     :members:
 
-=======
 MediaLive Helpers
 -------------------
 

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -139,8 +139,8 @@ class KinesisTests(TestCase):
         with stubber:
             actual = list(
                 yield_available_shard_records(
-                    'example-stream',
-                    shard_id,
+                    StreamName='example-stream',
+                    ShardId=shard_id,
                     ShardIteratorType='AT_TIMESTAMP',
                     Timestamp=dt,
                     kinesis_client=kinesis_client,
@@ -256,7 +256,7 @@ class KinesisTests(TestCase):
         with stubber:
             actual = list(
                 yield_available_stream_records(
-                    'example-stream', kinesis_client=kinesis_client
+                    StreamName='example-stream', kinesis_client=kinesis_client
                 )
             )
 

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -4,7 +4,11 @@ from unittest import TestCase
 from boto3 import client as boto3_client
 from botocore.stub import Stubber
 
-from boto3_helpers.kinesis import yield_all_shards
+from boto3_helpers.kinesis import (
+    yield_all_shards,
+    yield_available_shard_records,
+    yield_available_stream_records,
+)
 
 
 class KinesisTests(TestCase):
@@ -78,4 +82,189 @@ class KinesisTests(TestCase):
             )
 
         expected = page_1_resp['Shards'] + page_2_resp['Shards']
+        self.assertEqual(actual, expected)
+
+    def test_yield_available_shard_records(self):
+        # Set up the stubber
+        kinesis_client = boto3_client('kinesis', region_name='not-a-region')
+        stubber = Stubber(kinesis_client)
+        stream_name = 'example-stream'
+        shard_id = 'shard-0001'
+        dt = datetime(2022, 9, 7, 15, 11, 0, tzinfo=timezone.utc)
+        iterator_params_1 = {
+            'StreamName': stream_name,
+            'ShardId': shard_id,
+            'ShardIteratorType': 'AT_TIMESTAMP',
+            'Timestamp': dt,
+        }
+        iterator_resp_1 = {'ShardIterator': 'iterator-0001'}
+        stubber.add_response('get_shard_iterator', iterator_resp_1, iterator_params_1)
+
+        # The first call to get_records doesn't catch us up to the latest data,
+        # so another shard iterator is given.
+        records_params_1 = {'ShardIterator': 'iterator-0001'}
+        records_resp_1 = {
+            'Records': [
+                {
+                    'PartitionKey': shard_id,
+                    'SequenceNumber': '100000001',
+                    'Data': b'Record 1',
+                },
+                {
+                    'PartitionKey': shard_id,
+                    'SequenceNumber': '100000002',
+                    'Data': b'Record 2',
+                },
+            ],
+            'MillisBehindLatest': 1,
+            'NextShardIterator': 'iterator-0002',
+        }
+        stubber.add_response('get_records', records_resp_1, records_params_1)
+
+        # The second call does catch us up, so that's the end.
+        records_params_2 = {'ShardIterator': 'iterator-0002'}
+        records_resp_2 = {
+            'Records': [
+                {
+                    'PartitionKey': shard_id,
+                    'SequenceNumber': '100000003',
+                    'Data': b'Record 3',
+                },
+            ],
+            'MillisBehindLatest': 0,
+        }
+        stubber.add_response('get_records', records_resp_2, records_params_2)
+
+        # Do the deed
+        with stubber:
+            actual = list(
+                yield_available_shard_records(
+                    'example-stream',
+                    shard_id,
+                    ShardIteratorType='AT_TIMESTAMP',
+                    Timestamp=dt,
+                    kinesis_client=kinesis_client,
+                )
+            )
+
+        expected = [
+            records_resp_1['Records'][0],
+            records_resp_1['Records'][1],
+            records_resp_2['Records'][0],
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_yield_available_stream_records(self):
+        # Set up the stubber
+        kinesis_client = boto3_client('kinesis', region_name='not-a-region')
+        stubber = Stubber(kinesis_client)
+        stream_name = 'example-stream'
+        stream_shards = ['shard-a', 'shard-b', 'shard-c']
+
+        # This stream has two shards
+        list_params = {'StreamName': stream_name}
+        list_resp = {
+            'Shards': [
+                {
+                    'ShardId': stream_shards[0],
+                    'HashKeyRange': {
+                        'StartingHashKey': '100000000',
+                        'EndingHashKey': '19999999',
+                    },
+                    'SequenceNumberRange': {
+                        'StartingSequenceNumber': '100000000',
+                        'EndingSequenceNumber': '19999999',
+                    },
+                },
+                {
+                    'ShardId': stream_shards[1],
+                    'HashKeyRange': {
+                        'StartingHashKey': '200000000',
+                        'EndingHashKey': '29999999',
+                    },
+                    'SequenceNumberRange': {
+                        'StartingSequenceNumber': '200000000',
+                        'EndingSequenceNumber': '29999999',
+                    },
+                },
+            ],
+        }
+        stubber.add_response('list_shards', list_resp, list_params)
+
+        # The function will request a shard iterator for the first shard, then
+        # get records from it.
+        iterator_params_1 = {
+            'StreamName': stream_name,
+            'ShardId': stream_shards[0],
+            'ShardIteratorType': 'TRIM_HORIZON',
+        }
+        iterator_resp_1 = {'ShardIterator': 'iterator-a-1'}
+        stubber.add_response('get_shard_iterator', iterator_resp_1, iterator_params_1)
+
+        records_params_1 = {'ShardIterator': 'iterator-a-1'}
+        records_resp_1 = {
+            'Records': [
+                {
+                    'PartitionKey': stream_shards[0],
+                    'SequenceNumber': '100000001',
+                    'Data': b'Record a1',
+                },
+                {
+                    'PartitionKey': stream_shards[0],
+                    'SequenceNumber': '100000002',
+                    'Data': b'Record a2',
+                },
+            ],
+            'MillisBehindLatest': 0,
+        }
+        stubber.add_response('get_records', records_resp_1, records_params_1)
+
+        # Shard iterator and records for the second shard
+        iterator_params_2 = {
+            'StreamName': stream_name,
+            'ShardId': stream_shards[1],
+            'ShardIteratorType': 'TRIM_HORIZON',
+        }
+        iterator_resp_2 = {'ShardIterator': 'iterator-b-1'}
+        stubber.add_response('get_shard_iterator', iterator_resp_2, iterator_params_2)
+
+        records_params_2 = {'ShardIterator': 'iterator-b-1'}
+        records_resp_2 = {
+            'Records': [
+                {
+                    'PartitionKey': stream_shards[1],
+                    'SequenceNumber': '200000001',
+                    'Data': b'Record b1',
+                },
+                {
+                    'PartitionKey': stream_shards[1],
+                    'SequenceNumber': '200000002',
+                    'Data': b'Record b2',
+                },
+                {
+                    'PartitionKey': stream_shards[1],
+                    'SequenceNumber': '200000003',
+                    'Data': b'Record b3',
+                },
+            ],
+            'MillisBehindLatest': 0,
+        }
+        stubber.add_response('get_records', records_resp_2, records_params_2)
+
+        # Do the deed. Records from the two shards are interleaved together:
+        # A, B, A, B...
+        with stubber:
+            actual = list(
+                yield_available_stream_records(
+                    'example-stream', kinesis_client=kinesis_client
+                )
+            )
+
+        expected = [
+            records_resp_1['Records'][0],
+            records_resp_2['Records'][0],
+            records_resp_1['Records'][1],
+            records_resp_2['Records'][1],
+            records_resp_2['Records'][2],
+        ]
         self.assertEqual(actual, expected)

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timezone
+from unittest import TestCase
+
+from boto3 import client as boto3_client
+from botocore.stub import Stubber
+
+from boto3_helpers.kinesis import yield_all_shards
+
+
+class KinesisTests(TestCase):
+    def test_yield_all_shards(self):
+        # Set up the stubber
+        kinesis_client = boto3_client('kinesis', region_name='not-a-region')
+        stubber = Stubber(kinesis_client)
+
+        page_1_params = {
+            'StreamName': 'example-stream',
+            'ExclusiveStartShardId': 'shard-0001',
+            'StreamCreationTimestamp': datetime(
+                2022, 9, 2, 0, 0, 0, tzinfo=timezone.utc
+            ),
+            'MaxResults': 2,
+        }
+        page_1_resp = {
+            'Shards': [
+                {
+                    'ShardId': 'shard-0002',
+                    'HashKeyRange': {
+                        'StartingHashKey': '200000000',
+                        'EndingHashKey': '29999999',
+                    },
+                    'SequenceNumberRange': {
+                        'StartingSequenceNumber': '200000000',
+                        'EndingSequenceNumber': '29999999',
+                    },
+                },
+                {
+                    'ShardId': 'shard-0003',
+                    'HashKeyRange': {
+                        'StartingHashKey': '300000000',
+                        'EndingHashKey': '39999999',
+                    },
+                    'SequenceNumberRange': {
+                        'StartingSequenceNumber': '300000000',
+                        'EndingSequenceNumber': '39999999',
+                    },
+                },
+            ],
+            'NextToken': 'example-token',
+        }
+        stubber.add_response('list_shards', page_1_resp, page_1_params)
+
+        page_2_params = {
+            'NextToken': 'example-token',
+            'MaxResults': 2,
+        }
+        page_2_resp = {
+            'Shards': [
+                {
+                    'ShardId': 'shard-0004',
+                    'HashKeyRange': {
+                        'StartingHashKey': '400000000',
+                        'EndingHashKey': '49999999',
+                    },
+                    'SequenceNumberRange': {
+                        'StartingSequenceNumber': '400000000',
+                        'EndingSequenceNumber': '49999999',
+                    },
+                },
+            ],
+        }
+        stubber.add_response('list_shards', page_2_resp, page_2_params)
+
+        # Do the deed
+        with stubber:
+            actual = list(
+                yield_all_shards(kinesis_client=kinesis_client, **page_1_params)
+            )
+
+        expected = page_1_resp['Shards'] + page_2_resp['Shards']
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
This PR adds:
* `boto3_helpers.kinesis.yield_all_shards`
* `boto3_helpers.kinesis.yield_available_shard_records`
* `boto3_helpers.kinesis.yield_available_stream_records`

These three utility functions are designed to make it easier to read from Kinesis streams.