### PR TITLE
SQS Helpers

### DIFF
--- a/boto3_helpers/sqs.py
+++ b/boto3_helpers/sqs.py
@@ -1,0 +1,138 @@
+from secrets import token_hex
+
+from boto3 import client as boto3_client
+
+MESSAGE_LIMIT = 10
+SIZE_LIMIT = 262144
+
+
+def _get_size(message):
+    # The size of the message body is the size of the UTF-8 representation
+    ret = len(message['MessageBody'].encode('utf-8'))
+
+    # The size of the message attributes is computed as follows:
+    # 1. Encode the name: the length (4 bytes) and the UTF-8 bytes of the name.
+    # 2. Encode the data type: the length (4 bytes) and the UTF-8 bytes of the data
+    # type.
+    # 3. Encode the transport type (String or Binary) of the value (1 byte).
+    # 4a. For the String transport type, encode the attribute value: the length
+    # (4 bytes) and the UTF-8 bytes of the value.
+    # 4b. For the Binary transport type, encode the attribute value: the length
+    # (4 bytes) and the raw bytes of the value.
+    for attr_name, attr_data in message.get('MessageAttributes', {}).items():
+        ret += 4 + len(attr_name.encode('utf-8'))
+        ret += 4 + len(attr_data['DataType'].encode('utf-8'))
+        if 'StringValue' in attr_data:
+            ret += 1 + 4 + len(attr_data['StringValue'].encode('utf-8'))
+        elif 'BinaryValue' in attr_data:
+            ret += 1 + 4 + len(attr_data['BinaryValue'])
+        print(ret)
+
+    # MessageSystemAttributes don't count towards the total size of a message.
+    return ret
+
+
+def _get_batches(all_messages, message_limit, size_limit):
+    base_id = token_hex(4)
+    current_batch = []
+    current_size = 0
+    current_count = 0
+    for i, message in enumerate(all_messages, 1):
+        message.setdefault('Id', f'{base_id}-{i}')
+
+        message_size = _get_size(message)
+        reached_size = (current_size + message_size) > size_limit
+        reached_count = current_count == message_limit
+        if reached_size or reached_count:
+            yield current_batch[:]
+            del current_batch[:]
+            current_size = 0
+            current_count = 0
+
+        current_batch.append(message)
+        current_size += message_size
+        current_count += 1
+
+    if current_batch:
+        yield current_batch[:]
+
+
+def send_batches(
+    queue_url,
+    all_messages,
+    sqs_client=None,
+    message_limit=MESSAGE_LIMIT,
+    size_limit=SIZE_LIMIT,
+):
+    """Call ``send_message_batch`` as many times as necessary to deliver the messages
+    in *all_messages*, creating batches that fit SQS limits automatically.
+
+    * *queue_url* is the URL of the SQS queue.
+    * *all_messages* is an iterable of message entries, like what you would use for
+      ``send_message`` or ``send_message_batch``.
+    * *sqs_client* is a ``boto3.client('sqs')`` instance. If not given, is created
+      with ``boto3.client('sqs')``.
+    * *message_limit* is ``10`` by default. This is the maximum number of messages to
+      be sent per batch.
+    * *size_limit* is ``262_144`` (256 KiB) by default. This is the maximum batch
+      payload size.
+
+    Return value:
+
+    .. code-block:: python
+
+        {
+            'Successful': [
+                {
+                    'Id': 'string',
+                    'MessageId': 'string',
+                    'MD5OfMessageBody': 'string',
+                    'MD5OfMessageAttributes': 'string',
+                    'MD5OfMessageSystemAttributes': 'string',
+                    'SequenceNumber': 'string'
+                },
+            ],
+            'Failed': [
+                {
+                    'Id': 'string',
+                    'SenderFault': bool,
+                    'Code': 'string',
+                    'Message': 'string'
+                },
+            ]
+        }
+
+
+    If you don't supply an ``Id`` parameter in your messages, one will be inserted
+    automatically.
+
+    Messages from *all_messages* are collected in order. If the number of message
+    reaches the *message_limit* or the combined payload size of the messages reaches
+    *size_limit*, a new batch will be started. The size calculation includes message
+    attributes.
+
+    Usage:
+
+    .. code-block:: python
+
+        from boto3_helpers.sqs import send_batches
+
+        queue_url = 'https://sqs.test-region-1.amazonaws.com/000000000000/test-queue'
+        all_messages = [
+            {'MessageBody': 'Beautiful is better than ugly'},
+            {'MessageBody': 'Explicit is better than implicit', 'DelaySec': 120},
+            {'MessageBody': 'Simple is better than complex'},
+            # Fill this in with an arbitrary number of messages
+        ]
+        send_batches(queue_url, all_messages)
+
+    """
+    sqs_client = sqs_client or boto3_client('sqs')
+
+    ret = {'Successful': [], 'Failed': []}
+    for batch in _get_batches(all_messages, message_limit, size_limit):
+        resp = sqs_client.send_message_batch(QueueUrl=queue_url, Entries=batch)
+        ret['Successful'] += resp.get('Successful', [])
+        ret['Failed'] += resp.get('Failed', [])
+
+    return ret

--- a/boto3_helpers/sqs.py
+++ b/boto3_helpers/sqs.py
@@ -30,10 +30,16 @@ def _get_batches(all_messages, message_limit, size_limit):
     current_size = 0
     current_count = 0
     for i, message in enumerate(all_messages, 1):
-        message.setdefault('Id', f'{base_id}-{i}')
+        if message.get('Id') is None:
+            message['Id'] = f'{base_id}-{i}'
 
-        message_size = _get_size(message)
-        reached_size = (current_size + message_size) > size_limit
+        if size_limit is None:
+            message_size = 0
+            reached_size = False
+        if size_limit is not None:
+            message_size = _get_size(message)
+            reached_size = (current_size + message_size) > size_limit
+
         reached_count = current_count == message_limit
         if current_batch and (reached_size or reached_count):
             yield current_batch[:]
@@ -124,6 +130,76 @@ def send_batches(
     ret = {'Successful': [], 'Failed': []}
     for batch in _get_batches(all_messages, message_limit, size_limit):
         resp = sqs_client.send_message_batch(QueueUrl=queue_url, Entries=batch)
+        ret['Successful'] += resp.get('Successful', [])
+        ret['Failed'] += resp.get('Failed', [])
+
+    return ret
+
+
+def delete_batches(
+    queue_url, all_messages, sqs_client=None, message_limit=MESSAGE_LIMIT
+):
+    """Call ``delete_message_batch`` as many times as necessary to delete the messages
+    in *all_messages*, creating batches that fit SQS limits automatically.
+
+    * *queue_url* is the URL of the SQS queue.
+    * *all_messages* is an iterable of message entries, like what you would use for
+      ``delete_message`` or ``delete_message_batch``.
+    * *sqs_client* is a ``boto3.client('sqs')`` instance. If not given, is created
+      with ``boto3.client('sqs')``.
+    * *message_limit* is ``10`` by default. This is the maximum number of messages to
+      delete per batch.
+
+    Return value:
+
+    .. code-block:: python
+
+        {
+            'Successful': [
+                {
+                    'Id': 'string',
+                    'MessageId': 'string',
+                    'MD5OfMessageBody': 'string',
+                    'MD5OfMessageAttributes': 'string',
+                    'MD5OfMessageSystemAttributes': 'string',
+                    'SequenceNumber': 'string'
+                },
+            ],
+            'Failed': [
+                {
+                    'Id': 'string',
+                    'SenderFault': bool,
+                    'Code': 'string',
+                    'Message': 'string'
+                },
+            ]
+        }
+
+    The items in *all_messages* only need to have a ``ReceiptHandle`` key in them.
+    This means you can pass in messages you get from the ``receive_messages``
+    method directly.
+
+    Usage:
+
+    .. code-block:: python
+
+        from boto3_helpers.sqs import delete_batches
+
+        queue_url = 'https://sqs.test-region-1.amazonaws.com/000000000000/test-queue'
+        all_messages = [
+            {'ReceiptHandle': 'UmVjZWlwdCBoYW5kbGUgMQ=='},
+            {'ReceiptHandle': 'U2Vjb25kIHJlY2VpcHQgaGFuZGxl'},
+            {'Id': '24601', 'ReceiptHandle': 'VGhpcyBvbmUgaGFzIGl0cyBvd24gSUQ='},
+            # Fill this in with an arbitrary number of messages
+        ]
+        delete_batches(queue_url, all_messages)
+
+    """
+    sqs_client = sqs_client or boto3_client('sqs')
+    all_deletes = ({k: m.get(k) for k in ('Id', 'ReceiptHandle')} for m in all_messages)
+    ret = {'Successful': [], 'Failed': []}
+    for batch in _get_batches(all_deletes, message_limit, None):
+        resp = sqs_client.delete_message_batch(QueueUrl=queue_url, Entries=batch)
         ret['Successful'] += resp.get('Successful', [])
         ret['Failed'] += resp.get('Failed', [])
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,6 +32,12 @@ Pagination Helpers
 .. automodule:: boto3_helpers.pagination
     :members:
 
+SQS Helpers
+-----------
+
+.. automodule:: boto3_helpers.sqs
+    :members:
+
 STS Helpers
 -----------
 

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1,0 +1,94 @@
+from unittest import TestCase
+
+from boto3 import client as boto3_client
+from botocore.stub import Stubber
+
+from boto3_helpers.sqs import send_batches, _get_size
+
+
+class SQSTests(TestCase):
+    def test_get_size(self):
+        message = {
+            'MessageBody': '\U0001F574' * 10,
+            'MessageAttributes': {
+                'text': {'DataType': 'String', 'StringValue': '\U0001F574' * 2},
+                'data': {'DataType': 'Binary', 'BinaryValue': b'\x00' * 10},
+            },
+        }
+        self.assertEqual(_get_size(message), 104)
+
+    def test_send_batches(self):
+        # Prepare the arguments
+        queue_url = 'https://sqs.test-region-1.amazonaws.com/000000000000/test-queue'
+        all_messages = [
+            # Batch 1 cuts off because we reach 49 bytes
+            {'Id': '0000', 'MessageBody': '1234567890', 'DelaySeconds': 1},
+            {'Id': '0001', 'MessageBody': '1234567890'},
+            {'Id': '0002', 'MessageBody': '1234567890'},
+            {'Id': '0003', 'MessageBody': '1234567890'},
+            {'Id': '0004', 'MessageBody': '123456789'},
+            # Batch 2 cuts off because we reach 5 messages
+            {'Id': '0005', 'MessageBody': '1'},
+            {'Id': '0006', 'MessageBody': '1'},
+            {'Id': '0007', 'MessageBody': '1'},
+            {'Id': '0008', 'MessageBody': '1'},
+            {'Id': '0009', 'MessageBody': '1'},
+            # Batch 3 is just this one straggler
+            {'Id': '0010', 'MessageBody': '1'},
+        ]
+
+        # Set up the stubber
+        sqs_client = boto3_client('sqs', region_name='not-a-region')
+        stubber = Stubber(sqs_client)
+        expected = {'Successful': [], 'Failed': []}
+
+        batch_1 = all_messages[0:5]
+        send_params_1 = {'QueueUrl': queue_url, 'Entries': batch_1}
+        send_resp_1 = {'Successful': [], 'Failed': []}
+        for i, message in enumerate(batch_1):
+            item = {
+                'Id': str(i),
+                'MessageId': message['Id'],
+                'MD5OfMessageBody': '0' * 32,
+            }
+            send_resp_1['Successful'].append(item)
+            expected['Successful'].append(item)
+        stubber.add_response('send_message_batch', send_resp_1, send_params_1)
+
+        batch_2 = all_messages[5:10]
+        send_params_2 = {'QueueUrl': queue_url, 'Entries': batch_2}
+        send_resp_2 = {'Successful': [], 'Failed': []}
+        for i, message in enumerate(batch_2):
+            item = {
+                'Id': str(i),
+                'SenderFault': True,
+                'Code': 'Unknown',
+                'Message': '?',
+            }
+            send_resp_2['Failed'].append(item)
+            expected['Failed'].append(item)
+        stubber.add_response('send_message_batch', send_resp_2, send_params_2)
+
+        batch_3 = all_messages[10:]
+        send_params_3 = {'QueueUrl': queue_url, 'Entries': batch_3}
+        send_resp_3 = {'Successful': [], 'Failed': []}
+        for i, message in enumerate(batch_1):
+            item = {
+                'Id': str(i),
+                'MessageId': message['Id'],
+                'MD5OfMessageBody': '0' * 32,
+            }
+            send_resp_3['Successful'].append(item)
+            expected['Successful'].append(item)
+        stubber.add_response('send_message_batch', send_resp_3, send_params_3)
+
+        # Do the deed
+        with stubber:
+            actual = send_batches(
+                queue_url,
+                all_messages,
+                sqs_client=sqs_client,
+                message_limit=5,
+                size_limit=49,
+            )
+        self.assertEqual(actual, expected)

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -15,7 +15,7 @@ class SQSTests(TestCase):
                 'data': {'DataType': 'Binary', 'BinaryValue': b'\x00' * 10},
             },
         }
-        self.assertEqual(_get_size(message), 104)
+        self.assertEqual(_get_size(message), 78)
 
     def test_send_batches(self):
         # Prepare the arguments


### PR DESCRIPTION
This PR adds `boto3_helpers.sqs.send_batches`. This utility function is designed to make it easier to send batches of messages to an SQS queue.

Before: you have to worry about splitting batches up by message count (the limit is 10) and size (the limit is 256KiB).
After: you just call the function with all your message.

Similarly: `boto3_helpers.sqs.delete_batches` makes deleting an arbitrary number of messages easier.