### PR TITLE
CloudWatch helpers

### DIFF
--- a/boto3_helpers/cloudwatch.py
+++ b/boto3_helpers/cloudwatch.py
@@ -1,0 +1,96 @@
+from boto3 import client as boto3_client
+
+from boto3_helpers.pagination import yield_all_items
+
+
+def yield_metric_data(
+    namespace,
+    metric_name,
+    dimension_map,
+    period,
+    stat,
+    start_time,
+    end_time,
+    cw_client=None,
+    **kwargs,
+):
+    """Yield all the data associated with a single metric. Each item yielded is a
+    ``(dt, value)`` pair.
+
+    * *namespace* is the namespace for the metric.
+    * *metric_name* is the name of the metric.
+    * *dimension_map* is a ``dict`` that maps dimension names to values,
+      e.g. ``{'Name': 'Value'}``. If the metric has no dimension, supply an empty
+      ``dict``.
+    * *period* is the granularity of the returned data points in seconds.
+    * *stat* is the name of the statistic to evaluate, e.g. ``Maximum``.
+    * *start_time* is a ``datetime.datetime`` object that specifies that beginning
+      of the query.
+    * *end_time* is a ``datetime.datetime`` object that specifies that end
+      of the query.
+    * *cw_client* is a ``boto3.client('cloudwatch')`` instance. If not given, is
+      created with ``boto3.client('cloudwatch')``
+    * *kwargs* can include ``Unit``, ``Expression``, ``Period``, ``AccountId``,
+      ``ScanBy``, ``LabelOptions``, and ``PaginationConfig``. These are inserted
+      at the appropriate place in the ``get_paginator('get_metric_data').paginate``
+      call.
+
+    Usage:
+
+    .. code-block:: python
+
+        from boto3_helpers.cloudwatch import yield_metric_data
+        from datetime import datetime, timezone
+
+        for dt, value in yield_metric_data(
+            'AWS/S3',
+            'NumberOfObjects',
+            {'StorageType': 'AllStorageTypes', 'BucketName': 'example-bucket'},
+            86400,
+            'Maximum',
+            datetime.now(2022, 9, 1, 0, 0, 0, timezone.utc),
+            datetime.now(2022, 9, 16, 0, 0, 0, timezone.utc),
+        ):
+            print(dt.isoformat(), value, sep='\t')
+
+    This function is designed to simplify the common case of pulling all data for a
+    single metric, which is cumbersome with the normal CloudWatch ``get_metric_data``
+    method.
+
+    ``ScanBy`` is set to ``TimestampAscending`` by default, so data should be emitted
+    in sorted order.
+
+    """
+    cw_client = cw_client or boto3_client('cloudwatch')
+
+    metric_stat = {
+        'Metric': {
+            'Namespace': namespace,
+            'MetricName': metric_name,
+            'Dimensions': [{'Name': k, 'Value': v} for k, v in dimension_map.items()],
+        },
+        'Period': period,
+        'Stat': stat,
+    }
+    unit = kwargs.pop('Unit', None)
+    if unit is not None:
+        metric_stat['Unit'] = unit
+
+    query = {'Id': 'query0', 'MetricStat': metric_stat}
+    for key in ('Expression', 'Period', 'AccountId'):
+        value = kwargs.pop(key, None)
+        if value is not None:
+            query[key] = value
+
+    get_kwargs = {
+        'MetricDataQueries': [query],
+        'StartTime': start_time,
+        'EndTime': end_time,
+        'ScanBy': 'TimestampAscending',
+    }
+    get_kwargs.update(kwargs)
+
+    for item in yield_all_items(
+        cw_client, 'get_metric_data', 'MetricDataResults', **get_kwargs
+    ):
+        yield from zip(item['Timestamps'], item['Values'])

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,6 +2,12 @@ API Documentation
 =================
 
 
+CloudWatch Helpers
+----------------
+
+.. automodule:: boto3_helpers.cloudwatch
+    :members:
+
 DynamoDB Helpers
 ----------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,7 +3,7 @@ API Documentation
 
 
 CloudWatch Helpers
-----------------
+------------------
 
 .. automodule:: boto3_helpers.cloudwatch
     :members:

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -1,0 +1,108 @@
+from datetime import datetime, timezone, timedelta
+from copy import deepcopy
+from unittest import TestCase
+
+from boto3 import client as boto3_client
+from botocore.stub import Stubber
+
+from boto3_helpers.cloudwatch import yield_metric_data
+
+
+class CloudWatchTests(TestCase):
+    def test_yield_metric_data(self):
+        # Sample metric to fetch
+        namespace = 'MediaLive'
+        metric_name = 'FillMsec'
+        dimension_map = {'ChannelId': '24601', 'Pipeline': '0'}
+        period = 60
+        stat = 'Maximum'
+        start_time = datetime(2022, 9, 18, 0, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2022, 9, 18, 0, 5, 0, tzinfo=timezone.utc)
+        label_options = {'Timezone': '+0000'}
+
+        # Set up the stubber
+        cw_client = boto3_client('cloudwatch', region_name='not-a-region')
+        stubber = Stubber(cw_client)
+
+        # Page 1
+        page_1_params = {
+            'MetricDataQueries': [
+                {
+                    'Id': 'query0',
+                    'MetricStat': {
+                        'Metric': {
+                            'Namespace': namespace,
+                            'MetricName': metric_name,
+                            'Dimensions': [
+                                {'Name': 'ChannelId', 'Value': '24601'},
+                                {'Name': 'Pipeline', 'Value': '0'},
+                            ],
+                        },
+                        'Period': period,
+                        'Stat': stat,
+                    },
+                },
+            ],
+            'StartTime': start_time,
+            'EndTime': end_time,
+            'ScanBy': 'TimestampAscending',
+            'LabelOptions': label_options,
+        }
+        page_1_resp = {
+            'MetricDataResults': [
+                {
+                    'Id': 'query0',
+                    'Label': metric_name,
+                    'Timestamps': [
+                        start_time + timedelta(seconds=x) for x in range(0, 180, 60)
+                    ],
+                    'Values': [0.0, 0.0, 20000.0],
+                    'StatusCode': 'PartialData',
+                },
+            ],
+            'NextToken': 'test-token',
+        }
+        stubber.add_response('get_metric_data', page_1_resp, page_1_params)
+
+        # Page 2
+        page_2_params = deepcopy(page_1_params)
+        page_2_params['NextToken'] = 'test-token'
+
+        page_2_resp = {
+            'MetricDataResults': [
+                {
+                    'Id': 'query0',
+                    'Label': metric_name,
+                    'Timestamps': [
+                        start_time + timedelta(seconds=x) for x in range(180, 300, 60)
+                    ],
+                    'Values': [60000.0, 30000.0],
+                    'StatusCode': 'Complete',
+                },
+            ],
+        }
+        stubber.add_response('get_metric_data', page_2_resp, page_2_params)
+
+        # Do the deed - we expect to get the put response back
+        with stubber:
+            actual = list(
+                yield_metric_data(
+                    namespace,
+                    metric_name,
+                    dimension_map,
+                    period,
+                    stat,
+                    start_time,
+                    end_time,
+                    cw_client=cw_client,
+                    LabelOptions=label_options,
+                )
+            )
+        expected = [
+            (start_time + timedelta(seconds=0), 0.0),
+            (start_time + timedelta(seconds=60), 0.0),
+            (start_time + timedelta(seconds=120), 20000.0),
+            (start_time + timedelta(seconds=180), 60000.0),
+            (start_time + timedelta(seconds=240), 30000.0),
+        ]
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
This PR adds `boto3_helpers.cloudwatch.yield_metric_data`. This is a utility function designed to simplify pulling data from a CloudWatch metric.