### PR TITLE
Add boto3_helpers.signed_requests

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/boto3_helpers/signed_requests.py
+++ b/boto3_helpers/signed_requests.py
@@ -1,0 +1,67 @@
+from json import loads
+
+from boto3 import client as boto3_client
+from botocore.awsrequest import AWSRequest
+
+
+class SigV4RequestException(Exception):
+    """Exception raised by :func:`sigv4_request` when an HTTP response indicates an
+    error.
+    """
+
+    def __init__(self, status_code, content):
+        self.status_code = status_code
+        self.content = content
+
+
+def sigv4_request(service, method, endpoint, client=None, operation_name=None):
+    """Make a signed request to the AWS API and return the JSON payload.
+
+    * *service* is the AWS API service code
+    * *method* is an HTTP method like ``'GET'`` or ``'POST'``
+    * *endpoint* is the target API endpoint. If you need to supply parameters, put
+      supply them as a query string here (e.g., ``?MaxResults=1``)
+    * *client* is a ``boto3.client`` instance for the same account and region as your
+      target. If not given, is created with ``boto3.client('sts')``
+    * *operation_name* is the name of the API operation to use when signing the request
+
+    If the API response indicates an error,
+    ``boto3_helpers.signed_requests.SigV4RequestException`` will be raised.
+
+    This function is useful for accessing endpoints that aren't supported by ``boto3``.
+    For example, ``botocore`` introduced support for the ``'scheduler'`` service in
+    version 1.29.7. You could have used this function to interact with that API
+    before this new version was available:
+
+    .. code-block:: python
+
+        from boto3_helpers.signed_requests import sigv4_request
+
+        schedule_data = sigv4_request('scheduler', 'GET', 'schedules')
+
+    Explanation:
+
+    * The EventBridge Scheduler API Reference describes the ``ListSchedules`` API
+      action.
+    * The service code for EventBridge Scheduler is ``'scheduler'``.
+    * The method for ``ListSchedules`` is ``'GET'``.
+    * The endpoint is ``'/schedules'``. This function will strip off leading slashes.
+
+    We could haved optionally supplied the ``operation_name`` as ``'ListSchedules'``.
+
+    """
+    client = client or boto3_client('sts')
+
+    endpoint = endpoint.lstrip('/')
+    url = f'https://{service}.{client.meta.region_name}.amazonaws.com/{endpoint}'
+
+    request = AWSRequest(method=method, url=url)
+    client._request_signer.sign(operation_name, request, signing_name=service)
+    request.prepare()
+    request.headers = dict(request.headers)
+
+    resp = client._endpoint.http_session.send(request)
+    if not (200 <= resp.status_code <= 299):
+        raise SigV4RequestException(resp.status_code, resp.content)
+
+    return loads(resp.content)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,6 +50,12 @@ S3 Helpers
 .. automodule:: boto3_helpers.s3
     :members:
 
+Signed Request Helpers
+----------------------
+
+.. automodule:: boto3_helpers.signed_requests
+    :members:
+
 SQS Helpers
 -----------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = boto3-helpers
-version = 1.1.0
+version = 1.2.0
 description = Helper utilities for boto3
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/tests/test_signed_requests.py
+++ b/tests/test_signed_requests.py
@@ -1,0 +1,51 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from boto3_helpers.signed_requests import SigV4RequestException, sigv4_request
+
+
+class SigV4RequestTests(TestCase):
+    def test_call_succeeds(self):
+        _client = MagicMock()
+        _client.meta.region_name = 'test-region-1'
+        _client._endpoint.http_session.send.return_value = MagicMock(
+            status_code=200, content=b'{"NextToken": null, "Schedules": []}'
+        )
+
+        service = 'scheduler'
+        method = 'GET'
+        endpoint = '/schedules?MaxResults=1'
+        operation_name = 'ListSchedules'
+        actual = sigv4_request(
+            service,
+            method,
+            endpoint,
+            client=_client,
+            operation_name=operation_name,
+        )
+        expected = {'NextToken': None, 'Schedules': []}
+        self.assertEqual(actual, expected)
+
+        sign_call = _client._request_signer.sign.call_args
+        self.assertEqual(sign_call[0][0], operation_name)
+        self.assertEqual(sign_call[0][1].method, method)
+        self.assertEqual(
+            sign_call[0][1].url,
+            'https://scheduler.test-region-1.amazonaws.com/schedules?MaxResults=1',
+        )
+        self.assertEqual(sign_call[1], {'signing_name': service})
+
+        _client._endpoint.http_session.send.assert_called_once_with(sign_call[0][1])
+
+    def test_call_fails(self):
+        _client = MagicMock()
+        _client.meta.region_name = 'test-region-1'
+        _client._endpoint.http_session.send.return_value = MagicMock(
+            status_code=400, content=b'<UnknownOperationException/>\n'
+        )
+
+        with self.assertRaises(SigV4RequestException) as cm:
+            sigv4_request('scheduler', 'GET', '/yolo', client=_client)
+
+        self.assertEqual(cm.exception.status_code, 400)
+        self.assertEqual(cm.exception.content, b'<UnknownOperationException/>\n')


### PR DESCRIPTION
This PR adds `boto3_helpers.signed_requests`, a function designed to aid in calling AWS API endpoints that aren't supported by `boto3` and `botocore`.