### PR TITLE
Add kwargs to sigv4_request

### DIFF
--- a/boto3_helpers/signed_requests.py
+++ b/boto3_helpers/signed_requests.py
@@ -15,7 +15,7 @@ class SigV4RequestException(Exception):
 
 
 def sigv4_request(
-    service, method, endpoint, client=None, base_url=None, operation_name=None
+    service, method, endpoint, client=None, base_url=None, operation_name=None, **kwargs
 ):
     """Make a signed request to the AWS API and return the JSON payload.
 
@@ -28,6 +28,7 @@ def sigv4_request(
     * *base_url* is the URL for the target AWS API. If not given, a guess will be made
       based on the service name and client region.
     * *operation_name* is the name of the API operation to use when signing the request
+    * **kwargs** are passed on to an ``AWSRequest`` object.
 
     If the API response indicates an error,
     ``boto3_helpers.signed_requests.SigV4RequestException`` will be raised.
@@ -53,6 +54,19 @@ def sigv4_request(
 
     We could haved optionally supplied the ``operation_name`` as ``'ListSchedules'``.
 
+    Example: Invoking a Lambda function URL that uses the ``AWS_IAM`` auth type:
+
+    .. code-block:: python
+
+        from boto3_helpers.signed_requests import sigv4_request
+
+        resp = sigv4_request(
+            'lambda',
+            'POST',
+            '/',
+            base_url='https://660d26cd.lambda-url.test-region-1.on.aws',
+            data=dumps({'payload_key_1': 'payload_value_1'})
+        )
     """
     client = client or boto3_client('sts')
 
@@ -60,7 +74,7 @@ def sigv4_request(
     endpoint = endpoint.lstrip('/')
     url = f'{base_url}/{endpoint}'
 
-    request = AWSRequest(method=method, url=url)
+    request = AWSRequest(method=method, url=url, **kwargs)
     client._request_signer.sign(operation_name, request, signing_name=service)
     request.prepare()
     request.headers = dict(request.headers)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = boto3-helpers
-version = 1.2.0
+version = 1.3.0
 description = Helper utilities for boto3
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/tests/test_signed_requests.py
+++ b/tests/test_signed_requests.py
@@ -13,7 +13,7 @@ class SigV4RequestTests(TestCase):
         )
 
         service = 'scheduler'
-        method = 'GET'
+        method = 'POST'
         endpoint = '/schedules?MaxResults=1'
         operation_name = 'ListSchedules'
         actual = sigv4_request(
@@ -22,6 +22,7 @@ class SigV4RequestTests(TestCase):
             endpoint,
             client=_client,
             operation_name=operation_name,
+            data='{"test": "payload"}',
         )
         expected = {'NextToken': None, 'Schedules': []}
         self.assertEqual(actual, expected)
@@ -29,6 +30,7 @@ class SigV4RequestTests(TestCase):
         sign_call = _client._request_signer.sign.call_args
         self.assertEqual(sign_call[0][0], operation_name)
         self.assertEqual(sign_call[0][1].method, method)
+        self.assertEqual(sign_call[0][1].data, '{"test": "payload"}')
         self.assertEqual(
             sign_call[0][1].url,
             'https://scheduler.test-region-1.amazonaws.com/schedules?MaxResults=1',


### PR DESCRIPTION
This PR updates `sigv4_request` such that it passes on keyword arguments to the `AWSRequest` object it creates.