### PR TITLE
Allow jmespath expression for yield_all_items

### DIFF
--- a/boto3_helpers/pagination.py
+++ b/boto3_helpers/pagination.py
@@ -1,3 +1,6 @@
+from jmespath import search as json_search
+
+
 def yield_all_items(boto_client, method_name, list_key, **kwargs):
     """A helper function that simplifies retrieving items from API endpoints that
     require paging. Yields each item from every page:
@@ -46,4 +49,4 @@ def yield_all_items(boto_client, method_name, list_key, **kwargs):
     """
     paginator = boto_client.get_paginator(method_name)
     for page in paginator.paginate(**kwargs):
-        yield from page.get(list_key, [])
+        yield from json_search(list_key, page) or []

--- a/boto3_helpers/pagination.py
+++ b/boto3_helpers/pagination.py
@@ -46,9 +46,9 @@ def yield_all_items(boto_client, method_name, list_key, **kwargs):
             print(item['Key'])
 
     In this example, the ``list_key`` for S3's ``list_objects_v2`` is ``'Contents'``.
-    
+
     CloudFront example:
-    
+
     .. code-block:: python
 
         from boto3 import client as boto3_client

--- a/boto3_helpers/pagination.py
+++ b/boto3_helpers/pagination.py
@@ -8,7 +8,8 @@ def yield_all_items(boto_client, method_name, list_key, **kwargs):
     * *boto_client* is a ``boto3.client()`` instance for the relevant service.
     * *method_name* is the name of the client method that requires paging.
     * *list_key* is the name of the top-level key in the method's response that
-      corresponds to the desired list of items.
+      corresponds to the desired list of items. If the method's response has multiple
+      levels, use a ``jmespath`` expression.
     * *kwargs* are passed through to the appropriate ``paginate`` method.
 
     EC2 example:
@@ -45,6 +46,21 @@ def yield_all_items(boto_client, method_name, list_key, **kwargs):
             print(item['Key'])
 
     In this example, the ``list_key`` for S3's ``list_objects_v2`` is ``'Contents'``.
+    
+    CloudFront example:
+    
+    .. code-block:: python
+
+        from boto3 import client as boto3_client
+        from boto3_helpers.pagination import yield_all_items
+
+        cloudfront_client = boto3_client('cloudfront')
+        for item in yield_all_items(
+            cloudfront_client,
+            'list_distributions',
+            'DistributionList.Items'
+        ):
+            print(item['Id'])
 
     """
     paginator = boto_client.get_paginator(method_name)


### PR DESCRIPTION
This PR changes the the `list_key` argument to `yield_all_items` such that it can now be a `jmespath` expression. This allows the paginator to be used with API calls like CloudFront's [`list_distributions`](https://boto3.amazonaws.com/v1/documentation/api/1.26.13/reference/services/cloudfront.html#CloudFront.Client.list_distributions).