### PR TITLE
Add medialive.delete_schedule_action_chain

### DIFF
--- a/boto3_helpers/medialive.py
+++ b/boto3_helpers/medialive.py
@@ -1,0 +1,62 @@
+from collections import defaultdict
+
+from boto3 import client as boto3_client
+from jmespath import search as json_search
+
+from boto3_helpers.pagination import yield_all_items
+
+PARENT_ACTION_PATH = (
+    'ScheduleActionStartSettings'
+    '.FollowModeScheduleActionStartSettings'
+    '.ReferenceActionName'
+)
+
+
+def delete_schedule_action_chain(
+    channel_id, delete_action_name, eml_client=None, dry_run=False
+):
+    eml_client = eml_client or boto3_client('medialive')
+
+    # Associate each item on the schedule with its immediate ancestor.
+    all_action_names = set()
+    immediate_parent_map = {}
+    for schedule_action in yield_all_items(
+        eml_client, 'describe_schedule', 'ScheduleActions', ChannelId=channel_id
+    ):
+        action_name = schedule_action['ActionName']
+        all_action_names.add(action_name)
+
+        parent_name = json_search(PARENT_ACTION_PATH, schedule_action)
+        if parent_name:
+            immediate_parent_map[action_name] = parent_name
+
+    # If the target action was not in the schedule, bail out early.
+    if delete_action_name not in all_action_names:
+        raise ValueError(
+            f'Action name {delete_action_name} was not present in the schedule'
+        )
+
+    # Associate each item on the schedule with its ultimate ancestor, and each
+    # ultimate ancestor with all of its descendents.
+    ultimate_parent_map = {}
+    children_map = defaultdict(set)
+    for action_name in all_action_names:
+        parent_action_name = action_name
+        while parent_action_name in immediate_parent_map:
+            parent_action_name = immediate_parent_map[parent_action_name]
+
+        parent_action_name = parent_action_name or action_name
+        ultimate_parent_map[action_name] = parent_action_name
+        children_map[parent_action_name].add(action_name)
+
+    # Find the chain of actions associated with our target action.
+    delete_action_parent_name = ultimate_parent_map[delete_action_name]
+    all_deletes = sorted(children_map[delete_action_parent_name])
+
+    # Exceute the deletion.
+    if not dry_run:
+        eml_client.batch_update_schedule(
+            ChannelId=channel_id, Deletes={'ActionNames': all_deletes}
+        )
+
+    return all_deletes

--- a/boto3_helpers/medialive.py
+++ b/boto3_helpers/medialive.py
@@ -12,48 +12,64 @@ PARENT_ACTION_PATH = (
 )
 
 
-def delete_schedule_action_chain(
-    channel_id, delete_action_name, eml_client=None, dry_run=False
-):
-    eml_client = eml_client or boto3_client('medialive')
-
-    # Associate each item on the schedule with its immediate ancestor.
-    all_action_names = set()
-    immediate_parent_map = {}
-    for schedule_action in yield_all_items(
-        eml_client, 'describe_schedule', 'ScheduleActions', ChannelId=channel_id
-    ):
+def _parse_action_chains(eml_actions):
+    parent_map = {}
+    children_map = defaultdict(set)
+    for schedule_action in eml_actions:
         action_name = schedule_action['ActionName']
-        all_action_names.add(action_name)
 
-        parent_name = json_search(PARENT_ACTION_PATH, schedule_action)
-        if parent_name:
-            immediate_parent_map[action_name] = parent_name
+        parent_name = json_search(PARENT_ACTION_PATH, schedule_action) or action_name
+        parent_map[action_name] = parent_name
+        children_map[action_name].add(action_name)
 
-    # If the target action was not in the schedule, bail out early.
-    if delete_action_name not in all_action_names:
+        while True:
+            children_map[parent_name].add(action_name)
+            if parent_name == parent_map[parent_name]:
+                break
+            parent_name = parent_map[parent_name]
+
+    return parent_map, children_map
+
+
+def delete_schedule_action_chain(
+    channel_id, delete_action_name, dry_run=False, eml_client=None
+):
+    """Delete a MediaLive scheduled action, plus any actions that depend on it.
+    Return the names of the actions that were deleted.
+
+    * *channel_id* is the MediaLive channel ID.
+    * *delete_action_name* is the name of the scheduled action to delete.
+    * *dry_run* determines whether the delete actions are actually executed. Set to
+      ``False`` to return the names of the actions that _would_ have been deleted.
+    * *eml_client* (optional) is a ``boto3.client('medialive')`` instance.
+
+    Usage:
+
+    .. code-block:: python
+
+        from boto3_helpers.medialive import delete_schedule_action_chain
+
+        deleted_actions = delete_schedule_action_chain(
+            '24601', 'switch-immediate'
+        )
+
+    MediaLive's deletion rules still apply: you can't delete an action chain associated
+    with the most recent input switch.
+
+    """
+    eml_client = eml_client or boto3_client('medialive')
+    eml_actions = yield_all_items(
+        eml_client, 'describe_schedule', 'ScheduleActions', ChannelId=channel_id
+    )
+    parent_map, children_map = _parse_action_chains(eml_actions)
+
+    if delete_action_name not in parent_map:
         raise ValueError(
             f'Action name {delete_action_name} was not present in the schedule'
         )
 
-    # Associate each item on the schedule with its ultimate ancestor, and each
-    # ultimate ancestor with all of its descendents.
-    ultimate_parent_map = {}
-    children_map = defaultdict(set)
-    for action_name in all_action_names:
-        parent_action_name = action_name
-        while parent_action_name in immediate_parent_map:
-            parent_action_name = immediate_parent_map[parent_action_name]
+    all_deletes = sorted(children_map[delete_action_name])
 
-        parent_action_name = parent_action_name or action_name
-        ultimate_parent_map[action_name] = parent_action_name
-        children_map[parent_action_name].add(action_name)
-
-    # Find the chain of actions associated with our target action.
-    delete_action_parent_name = ultimate_parent_map[delete_action_name]
-    all_deletes = sorted(children_map[delete_action_parent_name])
-
-    # Exceute the deletion.
     if not dry_run:
         eml_client.batch_update_schedule(
             ChannelId=channel_id, Deletes={'ActionNames': all_deletes}

--- a/boto3_helpers/mediatailor.py
+++ b/boto3_helpers/mediatailor.py
@@ -4,9 +4,9 @@ from boto3 import client as boto3_client
 def update_playback_configuration(config_name, emt_client=None, **config_kwargs):
     """Do a partial update of a MediaTailor configuration and return the result:
 
+    * *config_name* is the name of the playback configuration that will be updated.
     * *emt_client* is a ``boto3.client('mediatailor')`` instance. If not given, is
       created with ``boto3.client('mediatailor')``.
-    * *config_name* is the name of the playback configuration that will be updated.
     * *config_kwargs* are passed directly to the ``put_playback_configuration`` method.
 
     Usage:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,6 +32,12 @@ Lambda Helpers
 .. automodule:: boto3_helpers.awslambda
     :members:
 
+MediaLive Helpers
+-------------------
+
+.. automodule:: boto3_helpers.medialive
+    :members:
+
 MediaTailor Helpers
 -------------------
 

--- a/tests/test_medialive.py
+++ b/tests/test_medialive.py
@@ -1,0 +1,145 @@
+from unittest import TestCase
+
+from boto3 import client as boto3_client
+from botocore.stub import Stubber
+
+from boto3_helpers.medialive import delete_schedule_action_chain
+
+TEST_SCHEDULE_ACTIONS = [
+    # Beginning of the first chain
+    {
+        'ActionName': 'chain_1',
+        'ScheduleActionStartSettings': {
+            'FixedModeScheduleActionStartSettings': {'Time': '2018-11-05T16:10:30.000Z'}
+        },
+        'ScheduleActionSettings': {},
+    },
+    # One level down
+    {
+        'ActionName': 'chain_1_1',
+        'ScheduleActionStartSettings': {
+            'FollowModeScheduleActionStartSettings': {
+                'ReferenceActionName': 'chain_1',
+                'FollowPoint': 'END',
+            },
+        },
+        'ScheduleActionSettings': {},
+    },
+    # Two levels down
+    {
+        'ActionName': 'chain_1_1_1',
+        'ScheduleActionStartSettings': {
+            'FollowModeScheduleActionStartSettings': {
+                'ReferenceActionName': 'chain_1_1',
+                'FollowPoint': 'END',
+            },
+        },
+        'ScheduleActionSettings': {},
+    },
+    # One level down again
+    {
+        'ActionName': 'chain_1_2',
+        'ScheduleActionStartSettings': {
+            'FollowModeScheduleActionStartSettings': {
+                'ReferenceActionName': 'chain_1',
+                'FollowPoint': 'END',
+            },
+        },
+        'ScheduleActionSettings': {},
+    },
+    # Standalone action
+    {
+        'ActionName': 'chain_2',
+        'ScheduleActionStartSettings': {
+            'FixedModeScheduleActionStartSettings': {'Time': '2018-11-05T16:20:30.000Z'}
+        },
+        'ScheduleActionSettings': {},
+    },
+]
+
+
+class MediaLiveTests(TestCase):
+    def test_delete_schedule_action_chain(self):
+        # Try deleting each action in a chain; the result should be the same each time.
+        channel_id = '24601'
+        deletion_chain = ['chain_1', 'chain_1_1', 'chain_1_1_1', 'chain_1_2']
+
+        for delete_action_name in deletion_chain:
+            with self.subTest(delete_action_name=delete_action_name):
+                # Set up the stubber
+                eml_client = boto3_client('medialive', region_name='not-a-region')
+                stubber = Stubber(eml_client)
+
+                # First command is describe_schedule
+                describe_resp = {'ScheduleActions': TEST_SCHEDULE_ACTIONS}
+                describe_params = {'ChannelId': channel_id}
+                stubber.add_response(
+                    'describe_schedule', describe_resp, describe_params
+                )
+
+                # Second command is batch_update_schedule
+                update_resp = {}
+                update_params = {
+                    'ChannelId': channel_id,
+                    'Deletes': {'ActionNames': deletion_chain},
+                }
+                stubber.add_response(
+                    'batch_update_schedule', update_resp, update_params
+                )
+
+                # Do the deed
+                with stubber:
+                    actual = delete_schedule_action_chain(
+                        channel_id, delete_action_name, eml_client=eml_client
+                    )
+                self.assertEqual(actual, deletion_chain)
+
+    def test_delete_single(self):
+        # Delete a single action that's not part of a chain.
+        channel_id = '24601'
+        delete_action_name = 'chain_2'
+
+        # Set up the stubber
+        eml_client = boto3_client('medialive', region_name='not-a-region')
+        stubber = Stubber(eml_client)
+
+        # First command is describe_schedule
+        describe_resp = {'ScheduleActions': TEST_SCHEDULE_ACTIONS}
+        describe_params = {'ChannelId': channel_id}
+        stubber.add_response('describe_schedule', describe_resp, describe_params)
+
+        # Second command is batch_update_schedule
+        update_resp = {}
+        update_params = {
+            'ChannelId': channel_id,
+            'Deletes': {'ActionNames': [delete_action_name]},
+        }
+        stubber.add_response('batch_update_schedule', update_resp, update_params)
+
+        # Do the deed
+        with stubber:
+            actual = delete_schedule_action_chain(
+                channel_id, delete_action_name, eml_client=eml_client
+            )
+        self.assertEqual(actual, [delete_action_name])
+
+    def test_delete_not_found(self):
+        # Try deleting a non-existent action.
+        channel_id = '24601'
+        delete_action_name = 'chain_3'
+
+        # Set up the stubber
+        eml_client = boto3_client('medialive', region_name='not-a-region')
+        stubber = Stubber(eml_client)
+
+        # First command is describe_schedule
+        describe_resp = {'ScheduleActions': TEST_SCHEDULE_ACTIONS}
+        describe_params = {'ChannelId': channel_id}
+        stubber.add_response('describe_schedule', describe_resp, describe_params)
+
+        # There should be an error because the requested action is not present.
+        with self.assertRaises(ValueError):
+            with stubber:
+                delete_schedule_action_chain(
+                    channel_id, delete_action_name, eml_client=eml_client
+                )


### PR DESCRIPTION
This PR adds `boto3_helpers.medialive.delete_schedule_action_chain`, which deletes chains of scheduled actions in MediaLive. This provides functionality similar to that which exists in the web console.