### PR TITLE
Relax order requirements for _parse_action_chains

### DIFF
--- a/boto3_helpers/medialive.py
+++ b/boto3_helpers/medialive.py
@@ -14,12 +14,13 @@ PARENT_ACTION_PATH = (
 
 def _parse_action_chains(eml_actions):
     parent_map = {}
-    children_map = defaultdict(set)
     for schedule_action in eml_actions:
         action_name = schedule_action['ActionName']
-
         parent_name = json_search(PARENT_ACTION_PATH, schedule_action) or action_name
         parent_map[action_name] = parent_name
+
+    children_map = defaultdict(set)
+    for action_name, parent_name in parent_map.items():
         children_map[action_name].add(action_name)
 
         while True:

--- a/tests/test_medialive.py
+++ b/tests/test_medialive.py
@@ -6,7 +6,7 @@ from botocore.stub import Stubber
 from boto3_helpers.medialive import delete_schedule_action_chain
 
 TEST_SCHEDULE_ACTIONS = [
-    # One level down again
+    # One level down from the first chain
     {
         'ActionName': 'chain_1_2',
         'ScheduleActionStartSettings': {

--- a/tests/test_medialive.py
+++ b/tests/test_medialive.py
@@ -6,6 +6,17 @@ from botocore.stub import Stubber
 from boto3_helpers.medialive import delete_schedule_action_chain
 
 TEST_SCHEDULE_ACTIONS = [
+    # One level down again
+    {
+        'ActionName': 'chain_1_2',
+        'ScheduleActionStartSettings': {
+            'FollowModeScheduleActionStartSettings': {
+                'ReferenceActionName': 'chain_1',
+                'FollowPoint': 'END',
+            },
+        },
+        'ScheduleActionSettings': {},
+    },
     # Beginning of the first chain
     {
         'ActionName': 'chain_1',
@@ -31,17 +42,6 @@ TEST_SCHEDULE_ACTIONS = [
         'ScheduleActionStartSettings': {
             'FollowModeScheduleActionStartSettings': {
                 'ReferenceActionName': 'chain_1_1',
-                'FollowPoint': 'END',
-            },
-        },
-        'ScheduleActionSettings': {},
-    },
-    # One level down again
-    {
-        'ActionName': 'chain_1_2',
-        'ScheduleActionStartSettings': {
-            'FollowModeScheduleActionStartSettings': {
-                'ReferenceActionName': 'chain_1',
                 'FollowPoint': 'END',
             },
         },


### PR DESCRIPTION
This PR updates #13's code for removing EML action chains, allowing for out-of-order chains to be processed properly.